### PR TITLE
forwardRef to auto adjust Layout margin top added to menu

### DIFF
--- a/src/components/molecules/Menu/index.tsx
+++ b/src/components/molecules/Menu/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, forwardRef, ForwardedRef } from 'react'
 import {
   CenterTextContainer,
   Icon,
@@ -17,15 +17,15 @@ import { useDeviceType } from '../../../hooks'
 import { DeviceType } from '../../../hooks/types'
 import { MenuPros } from './types'
 
-export const Menu = ({
+export const Menu = forwardRef(({
   menuIcon,
   casperIcon,
   title,
   links,
   toggle,
   rightAction,
-  menuRef,
-}: MenuPros) => {
+  // ref
+}: MenuPros, ref: ForwardedRef<HTMLDivElement>) => {
   const deviceType = useDeviceType()
   const isMobile = deviceType === DeviceType.MOBILE
   const isTablet = deviceType === DeviceType.TABLET
@@ -39,7 +39,7 @@ export const Menu = ({
     <>
       {isMobile ? (
         <>
-          <MenuWrapperMobile ref={menuRef}>
+          <MenuWrapperMobile ref={ref}>
             <MobileMenuIcon onClick={toggleMenu}>
               <BurgerButton
                 key={'burger-' + uuidv4()}
@@ -78,7 +78,7 @@ export const Menu = ({
           </MobileMenuWrapper>
         </>
       ) : (
-        <MenuWrapper isTablet={isTablet} ref={menuRef}>
+        <MenuWrapper isTablet={isTablet} ref={ref}>
           <LeftTextContainer>
             <Icon src={menuIcon} width={28} height={28} alt={`${title} left icon`} />
             <MenuItem>
@@ -117,4 +117,4 @@ export const Menu = ({
       )}
     </>
   )
-}
+})

--- a/src/components/molecules/Menu/types.ts
+++ b/src/components/molecules/Menu/types.ts
@@ -26,7 +26,7 @@ export interface MenuPros {
   toggle?: ToggleProps
   rightAction?: OptAction
   children?: React.ReactNode
-  menuRef?: React.RefObject<HTMLDivElement>;
+  ref?: React.ForwardedRef<HTMLDivElement>
 }
 
 export interface IMenuWrapper {


### PR DESCRIPTION
This just adds the FowardRef to the menu component to let Layout component from the uniswap project to auto adjust the margin top based on the height of this menu, because there is a difference between mobile and desktop.

This change also prepares to other projects desings height differences.