### PR TITLE
fix textlink color to indicate is a link

### DIFF
--- a/src/components/atoms/AccountDeployBody/styles.ts
+++ b/src/components/atoms/AccountDeployBody/styles.ts
@@ -49,7 +49,7 @@ export const Text = styled.p`
 `
 
 export const TextLink = styled(Text)`
-  color: ${(props) => props.theme.color.modalText};
+  color: ${({ theme }) => theme.color.textLinkLight };
   cursor: pointer;
 `
 

--- a/src/styles/themes/themes.ts
+++ b/src/styles/themes/themes.ts
@@ -39,6 +39,7 @@ export interface theme {
         lavender: string
         modalText: string
         textInactive: string
+        textLinkLight: string
         notification: {
           title: string,
           message: string
@@ -243,6 +244,7 @@ export const defaultTheme: theme = {
         lavender: '#E3DFFD',
         modalText: '#715FF5',
         textInactive: '#767676',
+        textLinkLight: '#715FF5',
         notification: {
           title: '#000000',
           message: '#000000',
@@ -448,6 +450,7 @@ export const darkTheme: theme = {
         lavender: '#E3DFFD',
         modalText: '#FFFFFF',
         textInactive: '#FFFFFF',
+        textLinkLight: '#7AEDD4',
         notification: {
           title: '#FFFFFF',
           message: '#FFFFFF',


### PR DESCRIPTION

![image](https://github.com/Rengo-Labs/Rengo-UI-Kit/assets/37820276/956d405d-0bef-46a0-af36-f0b7bce46c8d)

Text links are now visible to the user.

QaTouch ID: [D0058](https://kreitech.qatouch.com/v2/defects/view/p/yVLr/did/m9aRd)