### PR TITLE
notification fix, manual close prop added

### DIFF
--- a/src/components/atoms/Notification/index.tsx
+++ b/src/components/atoms/Notification/index.tsx
@@ -29,16 +29,24 @@ const ICON_NAMES: IconNames = {
   @param {string} props.message - The message to display in the notification.
   @param {function} props.onClose - The function to execute when the notification is close.
   @param {number} props.autoCloseDelay - The autoCloseDelay number to close the notification.
+  @param {boolean} props.closeManually - The closeManually boolean to decide if the notification should close manually
   @return {JSX.Element} A React component that displays a notification.
   */
-export const Notification = ({ position, type, title, message, onClose, autoCloseDelay = 5000 }: NotificationProps) => {
+export const Notification = ({ position, type, title, message, onClose, autoCloseDelay = 5000, closeManually = false }: NotificationProps) => {
   const theme = useTheme() as theme;
   const deviceType = useDeviceType()
   const isMobile = deviceType === DeviceType.MOBILE
 
   useEffect(() => {
-    const interval = setInterval(() => onClose(), autoCloseDelay);
-    return () => clearInterval(interval);
+    let interval: ReturnType<typeof setInterval>
+    
+    if (!closeManually) {
+      interval = setInterval(() => onClose(), autoCloseDelay);
+    }
+
+    return () => {
+      clearInterval(interval)
+    };
   }, [])
 
   useEffect(() => {

--- a/src/components/atoms/Notification/types.ts
+++ b/src/components/atoms/Notification/types.ts
@@ -17,4 +17,5 @@ export interface NotificationProps {
   message: string
   onClose: () => void
   autoCloseDelay?: number
+  closeManually?: boolean
 }

--- a/src/components/molecules/NotificationMessage/index.tsx
+++ b/src/components/molecules/NotificationMessage/index.tsx
@@ -12,6 +12,7 @@ export interface NotificationMessageProps {
     type: string
     autoCloseDelay?: number
     position?: string
+    closeManually?: boolean
 }
 
 /**
@@ -23,6 +24,7 @@ export interface NotificationMessageProps {
  * @param {string} type  - Type of the notification (success, error, info)
  * @param {number | undefined} autoCloseDelay - Time in milliseconds to close the notification (milliseconds)
  * @param {string | undefined} position - Position of the notification (top, right, center)
+ * @param {boolean} closeManually - Boolean to decide if the notification should close manually
  * @returns {JSX.Element}
  * @constructor
  */
@@ -34,7 +36,8 @@ export const NotificationMessage = ({
                                         subtitle,
                                         type,
                                         autoCloseDelay = 5000,
-                                        position = 'top'
+                                        position = 'top',
+                                        closeManually
                                     }: NotificationMessageProps) => {
     const getNotificationType = (type: string) => {
         switch (type) {
@@ -75,6 +78,7 @@ export const NotificationMessage = ({
                     position={getNotificationPosition(position)}
                     onClose={onClose}
                     autoCloseDelay={autoCloseDelay}
+                    closeManually={closeManually}
                 />
             }
         </>

--- a/stories/atoms/Notification/Notification.stories.tsx
+++ b/stories/atoms/Notification/Notification.stories.tsx
@@ -22,5 +22,7 @@ Default.args = {
   type: 'success',
   // @ts-ignore
   position: 'top-center',
-  onClose: () => console.log('close')
+  onClose: () => console.log('close'),
+  closeManually: false,
+  autoCloseDelay: 5000
 };

--- a/stories/molecules/NotificationMessage/NotificationMessage.stories.tsx
+++ b/stories/molecules/NotificationMessage/NotificationMessage.stories.tsx
@@ -27,7 +27,8 @@ Info.args = {
     onClose: () => console.log('NotificationMessage'),
     title: 'Liquidity correctly removed',
     subtitle: "Checking the progress of your <a href='/deploy' target='_blank'>deploy</a>.",
-    type: 'info'
+    type: 'info',
+    closeManually: true
 }
 export const Error = Template.bind({})
 Error.args = {


### PR DESCRIPTION
Add a new parameter to the notification components to control if the component is manually close.

Qa Touch ID: **[D0066](https://kreitech.qatouch.com/v2/defects/view/p/yVLr/did/BjZWQ)**